### PR TITLE
Implement spotify token from configuration

### DIFF
--- a/slsk-batchdl/Program.cs
+++ b/slsk-batchdl/Program.cs
@@ -68,6 +68,7 @@ static class Program
     static string spotifyUrl = "";
     static string spotifyId = "";
     static string spotifySecret = "";
+    static string spotifyToken = "";
     static string ytKey = "";
     static string csvPath = "";
     static int csvColumnCount = -1;
@@ -223,6 +224,8 @@ static class Program
                             "\n" +
                             "\n  --spotify-id <id>              spotify client ID" +
                             "\n  --spotify-secret <secret>      spotify client secret" +
+                            "\n  --spotify-token <token>        spotify token generated on login. This is logged to console" +
+                            "\n                                 and can then be used to bypass opening a browser (useful for docker)" +
                             "\n" +
                             "\n  --youtube-key <key>            Youtube data API key" +
                             "\n  --get-deleted                  Attempt to retrieve titles of deleted videos from wayback" +
@@ -472,6 +475,10 @@ static class Program
                     case "--ss":
                     case "--spotify-secret":
                         spotifySecret = args[++i];
+                        break;
+                    case "-st":
+                    case "--spotify-token":
+                        spotifyToken = args[++i];
                         break;
                     case "--yk":
                     case "--youtube-key":
@@ -1130,16 +1137,18 @@ static class Program
             spotifyId = Console.ReadLine();
             Console.Write("Spotify client secret:");
             spotifySecret = Console.ReadLine();
+            Console.Write("Spotify token:");
+            spotifyToken = Console.ReadLine();
             Console.WriteLine();
         }
 
-        if (needLogin && (spotifyId == "" || spotifySecret == ""))
+        if (needLogin && spotifyToken == "" && (spotifyId == "" || spotifySecret == ""))
         {
             readSpotifyCreds();
         }
 
-        spotifyClient = new Spotify(spotifyId, spotifySecret);
-        await spotifyClient.Authorize(needLogin, removeTracksFromSource);
+        spotifyClient = new Spotify(spotifyId, spotifySecret, spotifyToken);
+        await spotifyClient.Authorize(needLogin && spotifyToken == "", removeTracksFromSource);
 
         if (spotifyUrl == "spotify-likes")
         {

--- a/slsk-batchdl/Spotify.cs
+++ b/slsk-batchdl/Spotify.cs
@@ -7,6 +7,7 @@ public class Spotify
     private EmbedIOAuthServer _server;
     private readonly string _clientId;
     private readonly string _clientSecret;
+    private readonly string _token;
     private SpotifyClient? _client;
     private bool loggedIn = false;
 
@@ -15,12 +16,13 @@ public class Spotify
     public const string encodedSpotifySecret = "Y2JlM2QxYTE5MzJkNDQ2MmFiOGUy3shTuf4Y2JhY2M3ZDdjYWU=";
     public bool UsedDefaultCredentials { get; private set; }
 
-    public Spotify(string clientId="", string clientSecret="")
+    public Spotify(string clientId="", string clientSecret="", string token="")
     {
         _clientId = clientId;
         _clientSecret = clientSecret;
+        _token = token;
 
-        if (_clientId == "" || _clientSecret == "")
+        if (token == "" && (_clientId == "" || _clientSecret == ""))
         {
             _clientId = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encodedSpotifyId.Replace("1bLaH9", "")));
             _clientSecret = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encodedSpotifySecret.Replace("3shTuf4", "")));
@@ -36,10 +38,15 @@ public class Spotify
         {
             var config = SpotifyClientConfig.CreateDefault();
 
+            if(_token != "") {
+                _client = new SpotifyClient(config.WithToken(_token));
+                loggedIn = true;
+            } else {
             var request = new ClientCredentialsRequest(_clientId, _clientSecret);
             var response = await new OAuthClient(config).RequestToken(request);
 
             _client = new SpotifyClient(config.WithToken(response.AccessToken));
+            }
         }
         else
         {
@@ -78,6 +85,8 @@ public class Spotify
                 _clientId, _clientSecret, response.Code, new Uri("http://localhost:48721/callback")
             )
         );
+
+        Console.WriteLine("Spotify token: " + tokenResponse.AccessToken);
 
         _client = new SpotifyClient(tokenResponse.AccessToken);
         loggedIn = true;


### PR DESCRIPTION
Makes headless usage of sldl easier #42

* Adds `--spotify-token` arg for users to provide their own token.
* If token is provided oauth flow doesn't run and browser does not need to open
* If oauth flow does run then token is logged to console

Allows a user to generate a token by running sldl locally and then use that token with a headless instance.