### PR TITLE
slsk-batchdl crashes when downloading an album

### DIFF
--- a/slsk-batchdl/Models/Track.cs
+++ b/slsk-batchdl/Models/Track.cs
@@ -117,8 +117,14 @@ namespace Models
             _lenTol = lenTol;
         }
 
-        public bool Equals(Track a, Track b)
+        public bool Equals(Track? a, Track? b)
         {
+            if (ReferenceEquals(a, b))
+                return true;
+                
+            if (a == null || b == null)
+                return false;
+
             if (a.Equals(b))
                 return true;
 

--- a/slsk-batchdl/Services/FileManager.cs
+++ b/slsk-batchdl/Services/FileManager.cs
@@ -84,7 +84,10 @@ public class FileManager
             tracks.Where(t => !t.IsNotAudio && t.State == TrackState.Downloaded && t.DownloadPath.Length > 0).Select(t => t.DownloadPath));
 
         foreach (var track in nonAudioToOrganize)
-        {
+        {   
+            if (track == null || additionalImages == null)
+                continue;
+
             if (remainingOnly && organized.Contains(track))
                 continue;
 

--- a/slsk-batchdl/Utilities/Printing.cs
+++ b/slsk-batchdl/Utilities/Printing.cs
@@ -41,6 +41,14 @@ public static class Printing
         if (nec != null || pref != null)
             cond = $" ({(necStr + prefStr).TrimEnd(' ', ',')})";
 
+        if (!Utils.ContainsOnlyAscii(displayText)) {
+            displayText = Utils.RemoveNonAscii(displayText);
+        }
+
+        if (!Utils.ContainsOnlyAscii(cond)) {
+            cond = Utils.RemoveNonAscii(cond);
+        }
+
         return displayText + cond;
     }
 

--- a/slsk-batchdl/Utilities/Printing.cs
+++ b/slsk-batchdl/Utilities/Printing.cs
@@ -1,5 +1,7 @@
 ﻿using Konsole;
 
+using System;
+using System.Text;
 using Models;
 using Enums;
 using ProgressBar = Konsole.ProgressBar;
@@ -9,6 +11,7 @@ using SlFile = Soulseek.File;
 public static class Printing
 {
     static readonly object consoleLock = new();
+    static Encoding ascii = Encoding.ASCII;
 
     public static string DisplayString(Track t, Soulseek.File? file = null, SearchResponse? response = null, FileConditions? nec = null,
         FileConditions? pref = null, bool fullpath = false, string customPath = "", bool infoFirst = false, bool showUser = true, bool showSpeed = false)
@@ -22,6 +25,10 @@ public static class Printing
         string user = showUser && response?.Username != null ? response.Username + "\\" : "";
         string speed = showSpeed && response?.Username != null ? $"({response.UploadSpeed / 1024.0 / 1024.0:F2}MB/s) " : "";
         string fname = fullpath ? file.Filename : (showUser ? "..\\" : "") + (customPath.Length == 0 ? Utils.GetFileNameSlsk(file.Filename) : customPath);
+        if (!Utils.ContainsOnlyAscii(fname)) {
+            Byte[] asciiEncoding = ascii.GetBytes(fname);
+            fname = ascii.GetString(asciiEncoding);
+        }
         string length = Utils.IsMusicFile(file.Filename) ? (file.Length ?? -1).ToString() + "s" : "";
         string displayText;
         if (!infoFirst)

--- a/slsk-batchdl/Utilities/Utils.cs
+++ b/slsk-batchdl/Utilities/Utils.cs
@@ -724,6 +724,38 @@ public static class Utils
         return textBuilder.ToString();
     }
 
+    public static bool ContainsOnlyAscii(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return false;
+
+        foreach (char c in input)
+        {
+            if (!char.IsAscii(c))
+                return false;
+        }
+        return true;
+    }
+    
+    public static string RemoveNonAscii(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return input;
+
+        StringBuilder cleanString = new StringBuilder();
+
+        foreach (char c in input)
+        {
+            if (c >= 32 && c <= 126)
+            {
+                cleanString.Append(c);
+            } else {
+                cleanString.Append('?');cleanString.Append(c);
+            }
+        }
+
+        return cleanString.ToString();
+    }
     static readonly Dictionary<char, char> diacriticChars = new()
     {
         { 'ä', 'a' }, { 'æ', 'a' }, { 'ǽ', 'a' }, { 'œ', 'o' }, { 'ö', 'o' }, { 'ü', 'u' },


### PR DESCRIPTION
In the current release, when an album download finishes, the program crashes.

The error message is as follows and can be duplicatable on windows and linux by downloading any album:

Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at FileManager.OrganizeAlbum(Track source, List`1 tracks, List`1 additionalImages, Boolean remainingOnly) in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Services\FileManager.cs:line 88
   at Program.DownloadAlbum(Config config, TrackListEntry tle) in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Program.cs:line 783
   at Program.<MainLoop>g__download|18_1(TrackListEntry tle, Config config, List`1 notFound, List`1 existing) in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Program.cs:line 484
   at Program.MainLoop() in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Program.cs:line 447
   at Program.Main(String[] args) in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Program.cs:line 65
   at Program.<Main>(String[] args)

Specifically, the issue is here in the FileManager.cs:

```
foreach (var track in nonAudioToOrganize)
        {
            if (remainingOnly && organized.Contains(track))
                continue;

            OrganizeNonAudio(track, parent, additionalImages.Contains(track));
        }
```

One issue (at the line if (remainingOnly && organized.Contains(track))) is due to not preforming a null check on track when parsing the non audio files to organize.  The implementation of HashSet.Contains() tries to find an equal hashcode between the two items and checks for equality using the class's comparator (in this case, track class equalscomparator) between the items. When trying to look for a null track in the hashset, eventually the search will end up excecuting a.equals(b) with a and b being null, causing a null pointer derefrence. The track class equality comparator was modified to accept null tracks, as well as handle the case safely where one or both of the tracks are null. This should also improve the overall stability of the program.

After fixing this issue, the following line (OrganizeNonAudio(track, parent, additionalImages.Contains(track))) also ran into a NullReferenceException error. This was due to derefrencing a null additionalImages using the contains method. Since OrgainizeNonAudio is not called elsewhere in the codebase, adding a simple null check for both additionalImages and track allows the program to run smoothly, and prevents further downstream errors with trying to derefrence track. 

To reproduce, I used the following settings: 

./sldl spotify-likes --album

sldl.conf:
username = xxxxxxxxxxxx
password = xxxxxxxxxxxx
pref-format = flac,alac,wavpack,ape,tta,shn 
fast-search = true
path=xxxxxxxxxxxx
spotify-id=xxxxxxxxxxxx
spotify-secret=xxxxxxxxxxxx 
spotify-token=xxxxxxxxxxxx
spotify-refresh=xxxxxxxxxxxx
name-format={artist} - {title}  
skip-music-dir=xxxxxxxxxxxx
#concurrent-downloads=10  
max-stale-time=12000
search-timeout=12000
pref-min-bitrate=320
pref-max-bitrate=320 
#album-parallel-search=true
skip-not-found=true****