### PR TITLE
slsk-batchdl crashes when downloading an album

### DIFF
--- a/slsk-batchdl/Models/Track.cs
+++ b/slsk-batchdl/Models/Track.cs
@@ -117,8 +117,14 @@ namespace Models
             _lenTol = lenTol;
         }
 
-        public bool Equals(Track a, Track b)
+        public bool Equals(Track? a, Track? b)
         {
+            if (ReferenceEquals(a, b))
+                return true;
+                
+            if (a == null || b == null)
+                return false;
+
             if (a.Equals(b))
                 return true;
 

--- a/slsk-batchdl/Services/FileManager.cs
+++ b/slsk-batchdl/Services/FileManager.cs
@@ -84,7 +84,10 @@ public class FileManager
             tracks.Where(t => !t.IsNotAudio && t.State == TrackState.Downloaded && t.DownloadPath.Length > 0).Select(t => t.DownloadPath));
 
         foreach (var track in nonAudioToOrganize)
-        {
+        {   
+            if (track == null || additionalImages == null)
+                continue;
+
             if (remainingOnly && organized.Contains(track))
                 continue;
 


### PR DESCRIPTION
In the current release, when an album download finishes, the program crashes.

The error message is as follows and can be duplicatable on windows and linux by downloading any album:

Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at FileManager.OrganizeAlbum(Track source, List`1 tracks, List`1 additionalImages, Boolean remainingOnly) in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Services\FileManager.cs:line 88
   at Program.DownloadAlbum(Config config, TrackListEntry tle) in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Program.cs:line 783
   at Program.<MainLoop>g__download|18_1(TrackListEntry tle, Config config, List`1 notFound, List`1 existing) in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Program.cs:line 484
   at Program.MainLoop() in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Program.cs:line 447
   at Program.Main(String[] args) in C:\Users\fiso\Source\repos\slsk-batchdl\slsk-batchdl\Program.cs:line 65
   at Program.<Main>(String[] args)

Specifically, the issue is here in the FileManager.cs:

```
foreach (var track in nonAudioToOrganize)
        {
            if (remainingOnly && organized.Contains(track))
                continue;

            OrganizeNonAudio(track, parent, additionalImages.Contains(track));
        }
```

One issue (at the line if (remainingOnly && organized.Contains(track))) is due to not preforming a null check on track when parsing the non audio files to organize.  The implementation of HashSet.Contains() tries to find an equal hashcode between the two items and checks for equality using the class's comparator (in this case, track class equalscomparator) between the items. When trying to look for a null track in the hashset, eventually the search will end up excecuting a.equals(b) with a and b being null, causing a null pointer derefrence. The track class equality comparator was modified to accept null tracks, as well as handle the case safely where one or both of the tracks are null. This should also improve the overall stability of the program.

After fixing this issue, the following line (OrganizeNonAudio(track, parent, additionalImages.Contains(track))) also ran into a NullReferenceException error. This was due to derefrencing a null additionalImages using the contains method. Since OrgainizeNonAudio is not called elsewhere in the codebase, adding a simple null check for both additionalImages and track allows the program to run smoothly, and prevents further downstream errors with trying to derefrence track. 

To reproduce, I used the following settings: 

./sldl spotify-likes --album

sldl.conf:
username = xxxxxxxxxxxx
password = xxxxxxxxxxxx
pref-format = flac,alac,wavpack,ape,tta,shn 
fast-search = true
path=xxxxxxxxxxxx
spotify-id=xxxxxxxxxxxx
spotify-secret=xxxxxxxxxxxx 
spotify-token=xxxxxxxxxxxx
spotify-refresh=xxxxxxxxxxxx
name-format={artist} - {title}  
skip-music-dir=xxxxxxxxxxxx
#concurrent-downloads=10  
max-stale-time=12000
search-timeout=12000
pref-min-bitrate=320
pref-max-bitrate=320 
#album-parallel-search=true
skip-not-found=true****