### PR TITLE
Spotify no longer allows localhost callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ liked songs. Credentials are required when downloading a private playlist or lik
 <details>
   <summary>Click to expand</summary>
 
-Create a Spotify application at https://developer.spotify.com/dashboard/applications with a redirect url http://localhost:48721/callback. Obtain an application ID and secret from the created application dashboard.
+Create a Spotify application at https://developer.spotify.com/dashboard/applications with a redirect url http://127.0.0.1:48721/callback. Obtain an application ID and secret from the created application dashboard.
 
 Start sldl with the obtained credentials and an authorized action to trigger the Spotify app login flow:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   sldl:
+    ports:
+    - "127.0.0.1:48721:48721"
     build:
       context: .
     environment:

--- a/slsk-batchdl/Extractors/Spotify.cs
+++ b/slsk-batchdl/Extractors/Spotify.cs
@@ -170,7 +170,7 @@ namespace Extractors
             else
             {
                 Swan.Logging.Logger.NoLogging();
-                _server = new EmbedIOAuthServer(new Uri("http://localhost:48721/callback"), 48721);
+                _server = new EmbedIOAuthServer(new Uri("http://127.0.0.1:48721/callback"), 48721);
                 await _server.Start();
 
                 Logger.Debug($"Spotify: AuthServer started");
@@ -236,7 +236,7 @@ namespace Extractors
             {
                 Logger.Info("Trying to renew access with refresh token...");
                 //     var refreshRequest = new TokenSwapRefreshRequest(
-                //     new Uri("http://localhost:48721/refresh"),
+                //     new Uri("http://127.0.0.1:48721/refresh"),
                 //     _clientRefreshToken
                 // );
                 var refreshRequest = new AuthorizationCodeRefreshRequest(_clientId, _clientSecret, _clientRefreshToken);
@@ -271,7 +271,7 @@ namespace Extractors
             Logger.Debug($"Spotify: Getting token response..");
             var tokenResponse = await new OAuthClient(config).RequestToken(
                 new AuthorizationCodeTokenRequest(
-                    _clientId, _clientSecret, response.Code, new Uri("http://localhost:48721/callback")
+                    _clientId, _clientSecret, response.Code, new Uri("http://127.0.0.1:48721/callback")
                 )
             );
 

--- a/slsk-batchdl/Help.cs
+++ b/slsk-batchdl/Help.cs
@@ -221,7 +221,7 @@ public static class Help
 
           Using Credentials
             Create a Spotify application at https://developer.spotify.com/dashboard/applications with a 
-            redirect url http://localhost:48721/callback. Obtain an application ID and secret from the 
+            redirect url http://127.0.0.1:48721/callback. Obtain an application ID and secret from the
             created application dashboard.  
             Start sldl with the obtained credentials and an authorized action to trigger the Spotify 
             app login flow:


### PR DESCRIPTION
Spotify no longer allows localhost for the redirect url. See the [Redirect URIs](https://developer.spotify.com/documentation/web-api/concepts/redirect_uri) docs. I tested this with the docker compose environment which also required forwarding the port, so I have included that change as well but I am happy to remove it if desired. Thanks for a great project!