### PR TITLE
Remove unnecessary `using` statements

### DIFF
--- a/slsk-batchdl.Tests/TestClients/MockSoulseekClient.cs
+++ b/slsk-batchdl.Tests/TestClients/MockSoulseekClient.cs
@@ -1,7 +1,4 @@
 using Soulseek;
-using Soulseek.Diagnostics;
-using System.Collections.Concurrent;
-using System.Net;
 
 namespace Tests.ClientTests
 {

--- a/slsk-batchdl.Tests/TestClients/MockSoulseekClientNotImpl.cs
+++ b/slsk-batchdl.Tests/TestClients/MockSoulseekClientNotImpl.cs
@@ -1,6 +1,5 @@
 using Soulseek;
 using Soulseek.Diagnostics;
-using System.Collections.Concurrent;
 using System.Net;
 
 namespace Tests.ClientTests

--- a/slsk-batchdl/Extractors/Soulseek.cs
+++ b/slsk-batchdl/Extractors/Soulseek.cs
@@ -1,10 +1,5 @@
 ﻿using Models;
 using Enums;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Web;
 using Soulseek;
 

--- a/slsk-batchdl/Extractors/YouTube.cs
+++ b/slsk-batchdl/Extractors/YouTube.cs
@@ -10,7 +10,6 @@ using System.Collections.Concurrent;
 
 using Models;
 using Enums;
-using Swan;
 
 namespace Extractors
 {

--- a/slsk-batchdl/Models/DownloadWrapper.cs
+++ b/slsk-batchdl/Models/DownloadWrapper.cs
@@ -1,6 +1,5 @@
 ﻿using Soulseek;
 using System.Collections.Concurrent;
-using static Program;
 using ProgressBar = Konsole.ProgressBar;
 using SearchResponse = Soulseek.SearchResponse;
 

--- a/slsk-batchdl/Services/Downloader.cs
+++ b/slsk-batchdl/Services/Downloader.cs
@@ -1,7 +1,6 @@
 ﻿using Soulseek;
 
 using Models;
-using static Program;
 
 using File = System.IO.File;
 using Directory = System.IO.Directory;

--- a/slsk-batchdl/Services/FileManager.cs
+++ b/slsk-batchdl/Services/FileManager.cs
@@ -2,7 +2,6 @@
 
 using Models;
 using Enums;
-using Soulseek;
 
 
 public class FileManager

--- a/slsk-batchdl/Services/InteractiveModeManager.cs
+++ b/slsk-batchdl/Services/InteractiveModeManager.cs
@@ -1,9 +1,5 @@
 ﻿using Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 public class InteractiveModeManager
 {

--- a/slsk-batchdl/Services/M3uEditor.cs
+++ b/slsk-batchdl/Services/M3uEditor.cs
@@ -1,7 +1,6 @@
 ﻿using Models;
 using Enums;
 using System.Text;
-using System.Diagnostics;
 
 
 public class M3uEditor // todo: separate into M3uEditor and IndexEditor

--- a/slsk-batchdl/Services/OnCompleteExecutor.cs
+++ b/slsk-batchdl/Services/OnCompleteExecutor.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Threading;
-using TagLib;
+﻿using System.Diagnostics;
 using Models;
 using Enums;
 

--- a/slsk-batchdl/Services/ResultSorter.cs
+++ b/slsk-batchdl/Services/ResultSorter.cs
@@ -1,13 +1,6 @@
 ﻿using Models;
 using Soulseek;
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using static Program;
 
 public static class ResultSorter
 {

--- a/slsk-batchdl/Services/Searcher.cs
+++ b/slsk-batchdl/Services/Searcher.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 
 using Models;
 using Enums;
-using static Program;
 using SearchResponse = Soulseek.SearchResponse;
 using SlResponse = Soulseek.SearchResponse;
 using SlFile = Soulseek.File;

--- a/slsk-batchdl/Utilities/Logger.cs
+++ b/slsk-batchdl/Utilities/Logger.cs
@@ -1,14 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using System;
-using System.Collections.Generic;
-using System.IO;
-
-public static class Logger
+﻿public static class Logger
 {
     public enum LogLevel
     {

--- a/slsk-batchdl/Utilities/TrackTemplateParser.cs
+++ b/slsk-batchdl/Utilities/TrackTemplateParser.cs
@@ -1,10 +1,6 @@
 using Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 public static class TrackTemplateParser
 {


### PR DESCRIPTION
I noticed a bunch of unnecessary `using` statements in the code. This PR removes them. Simple cleanup, no functional changes. :)