### PR TITLE
Log download completion

### DIFF
--- a/slsk-batchdl/Utilities/IntervalLogger.cs
+++ b/slsk-batchdl/Utilities/IntervalLogger.cs
@@ -1,0 +1,23 @@
+/// Utility class to handle interval-based logging.
+///
+/// See: https://johnscolaro.xyz/blog/log-by-time-not-by-count
+public class IntervalLogger
+{
+    public readonly TimeSpan Interval;
+    private DateTime lastLogged = new DateTime(0, DateTimeKind.Utc);
+
+    public IntervalLogger(TimeSpan interval)
+    {
+        this.Interval = interval;
+    }
+
+    public void MaybeLog(Action action)
+    {
+        var now = DateTime.UtcNow;
+        if (now - lastLogged > Interval)
+        {
+            lastLogged = now;
+            action();
+        }
+    }
+}


### PR DESCRIPTION
One issue I had with `sldl` is that it would download continually, but it wouldn't do a very good job telling me how far it had gotten working through all the downloads I set out for it. This patch sums up the total downloads to be completed before starting and then logs progress as it goes:

```
Succeeded:     pixelmelt\..\02 - All That's Left (feat. Joni Fatora) (The M Machine Remix).flac [466s/44.1kHz/54.3MB]
Completed 12/41 downloads = 29.268%
Succeeded:     cinstitute2\..\01. Saoirse Dream - weenie hut.flac [110s/44.1kHz/13.9MB]
Completed 13/41 downloads = 31.707%
Succeeded:     bunhill\..\02 - Underscores - NO REGRETS!!!.mp3 [-1s/5.5MB]
Completed 14/41 downloads = 34.146%
```