### PR TITLE
Ignore underscores in integer/double parameters

### DIFF
--- a/slsk-batchdl/Config.cs
+++ b/slsk-batchdl/Config.cs
@@ -725,15 +725,17 @@ public class Config
 
         int getIntParameter(ref int i)
         {
-            if (!int.TryParse(GetParameter(ref i), out var res))
-                InputError("Option requires integer parameter");
+            var value = GetParameter(ref i);
+            if (!int.TryParse(value.Replace("_", ""), out var res))
+                InputError($"Option requires integer parameter: {value}");
             return res;
         }
 
         double getDoubleParameter(ref int i)
         {
-            if (!double.TryParse(GetParameter(ref i), out var res))
-                InputError("Option requires double parameter");
+            var value = GetParameter(ref i);
+            if (!double.TryParse(value.Replace("_", ""), out var res))
+                InputError($"Option requires double parameter: {value}");
             return res;
         }
 


### PR DESCRIPTION
This allows users to write (e.g.) millisecond values in a much more legible fashion, and matches convenience features in the grammar in programming languages like Rust and Python that may be familiar to some config authors.

Before:

    max-stale-time = 600000

After:

    max-stale-time = 600_000