### PR TITLE
Fix warnings

### DIFF
--- a/slsk-batchdl/DownloaderApplication.cs
+++ b/slsk-batchdl/DownloaderApplication.cs
@@ -418,9 +418,8 @@ public class DownloaderApplication
                         foreach (var item in res)
                         {
                             var newSource = new Track(tle.source) { Type = TrackType.Album, ItemNumber = -1 };
-                            var albumTle = new TrackListEntry()
+                            var albumTle = new TrackListEntry(newSource)
                             {
-                                source = newSource,
                                 list = item,
                                 config = config,
                                 needSourceSearch = false,

--- a/slsk-batchdl/DownloaderApplication.cs
+++ b/slsk-batchdl/DownloaderApplication.cs
@@ -15,7 +15,6 @@ using SlFile = Soulseek.File;
 public class DownloaderApplication
 {
     private const int updateInterval = 100;
-    private bool initialized = false;
     private bool skipUpdate = false; // Will likely need rethinking later
     private bool interceptKeys = false; // UI concern, move later?
     private event EventHandler<ConsoleKey>? keyPressed; // UI concern, move later?

--- a/slsk-batchdl/Extractors/String.cs
+++ b/slsk-batchdl/Extractors/String.cs
@@ -11,7 +11,7 @@ namespace Extractors
             return !input.IsInternetUrl();
         }
 
-        public async Task<TrackLists> GetTracks(string input, int maxTracks, int offset, bool reverse, Config config)
+        public Task<TrackLists> GetTracks(string input, int maxTracks, int offset, bool reverse, Config config)
         {
             bool isAlbum = config.album;
 
@@ -38,7 +38,7 @@ namespace Extractors
 
             trackLists.AddEntry(tle);
 
-            return trackLists;
+            return Task.FromResult(trackLists);
         }
 
         public static Track ParseTrackArg(string input, bool isAlbum)

--- a/slsk-batchdl/Models/SimpleFile.cs
+++ b/slsk-batchdl/Models/SimpleFile.cs
@@ -13,6 +13,7 @@ namespace Models
 
         public SimpleFile(TagLib.File file)
         {
+            Path = file.Name;
             SetFromTagLib(file);
         }
 
@@ -21,6 +22,7 @@ namespace Models
             try
             {
                 var tagFile = TagLib.File.Create(path);
+                Path = tagFile.Name;
                 SetFromTagLib(tagFile);
             }
             catch

--- a/slsk-batchdl/Models/Track.cs
+++ b/slsk-batchdl/Models/Track.cs
@@ -125,8 +125,11 @@ namespace Models
             _lenTol = lenTol;
         }
 
-        public bool Equals(Track a, Track b)
+        public bool Equals(Track? a, Track? b)
         {
+            if (a == null || b == null)
+                return a == b;
+
             if (a.Equals(b))
                 return true;
 

--- a/slsk-batchdl/Models/TrackListEntry.cs
+++ b/slsk-batchdl/Models/TrackListEntry.cs
@@ -44,7 +44,11 @@ namespace Models
 
         private List<string>? printLines = null;
 
-        public TrackListEntry() { }
+        public TrackListEntry(Track source)
+        {
+            this.source = source;
+            SetDefaults();
+        }
 
         public TrackListEntry(TrackType trackType)
         {

--- a/slsk-batchdl/Utilities/Logger.cs
+++ b/slsk-batchdl/Utilities/Logger.cs
@@ -62,7 +62,8 @@
 
     public static void SetConsoleLogLevel(LogLevel logLevel)
     {
-        OutputConfigs.First(x => x.Output == Console.WriteLine).MinimumLevel = logLevel;
+        var consoleConfig = OutputConfigs.First(x => x.Output == Console.WriteLine);
+        consoleConfig.MinimumLevel = logLevel;
     }
 
     public static void AddFile(string filePath, LogLevel minimumLevel = LogLevel.Debug, bool prependDate = true, bool prependLogLevel = true)

--- a/slsk-batchdl/Utilities/Logger.cs
+++ b/slsk-batchdl/Utilities/Logger.cs
@@ -72,7 +72,11 @@
 
     public static void AddOrReplaceFile(string filePath, LogLevel minimumLevel = LogLevel.Debug, bool prependDate = true, bool prependLogLevel = true)
     {
-        Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+        var directoryName = Path.GetDirectoryName(filePath);
+        if (directoryName != null && directoryName != String.Empty)
+        {
+            Directory.CreateDirectory(directoryName);
+        }
         OutputConfigs.RemoveAll(config => config.IsFileOutput);
         AddOutput(message => File.AppendAllText(filePath, message + '\n'), minimumLevel, prependDate, prependLogLevel, isFileOutput: true);
     }

--- a/slsk-batchdl/Utilities/Logger.cs
+++ b/slsk-batchdl/Utilities/Logger.cs
@@ -11,7 +11,7 @@
         Fatal
     }
 
-    public class OutputConfig
+    public struct OutputConfig
     {
         public Action<string> Output;
         public LogLevel MinimumLevel;

--- a/slsk-batchdl/Utilities/Utils.cs
+++ b/slsk-batchdl/Utilities/Utils.cs
@@ -98,7 +98,15 @@ public static class Utils
     public static string GetDirectoryNameSlsk(string fname)
     {
         fname = fname.Replace('\\', Path.DirectorySeparatorChar);
-        return Path.GetDirectoryName(fname);
+        var directoryName = Path.GetDirectoryName(fname);
+        if (directoryName == null || directoryName == String.Empty)
+        {
+            return String.Empty;
+        }
+        else
+        {
+            return directoryName;
+        }
     }
 
     public static string ExpandVariables(string path)

--- a/slsk-batchdl/Utilities/Utils.cs
+++ b/slsk-batchdl/Utilities/Utils.cs
@@ -58,6 +58,18 @@ public static class Utils
         }
     }
 
+    public async static Task WriteAllLinesAsync(string path, IEnumerable<string> lines, char separator)
+    {
+        using (var writer = new StreamWriter(path))
+        {
+            foreach (var line in lines)
+            {
+                await writer.WriteAsync(line);
+                await writer.WriteAsync(separator);
+            }
+        }
+    }
+
     public static string GetFullPath(string path)
     {
         if (string.IsNullOrEmpty(path))


### PR DESCRIPTION
This patch fixes a bunch of warnings, mostly around nullable values. I can split these into one PR per commit if you'd like — would that be easier to review? Also, I don't know if you even care about the warnings at all, but they were bugging me so I fixed some of them.

Remaining warnings:

```
slsk-batchdl/DownloaderApplication.cs             58
slsk-batchdl/Extractors/Spotify.cs                43
slsk-batchdl/Utilities/Printing.cs                25
slsk-batchdl/Extractors/YouTube.cs                16
slsk-batchdl/Services/Searcher.cs                 11
slsk-batchdl/Utilities/JsonPrinter.cs             10
slsk-batchdl/Services/InteractiveModeManager.cs   9
slsk-batchdl/Services/TrackSkipper.cs             9
slsk-batchdl/Models/TrackLists.cs                 8
slsk-batchdl/Utilities/Utils.cs                   6
slsk-batchdl/Config.cs                            6
slsk-batchdl/Services/FileManager.cs              5
slsk-batchdl/Services/M3uEditor.cs                5
slsk-batchdl/Services/Downloader.cs               4
slsk-batchdl/Extractors/List.cs                   4
slsk-batchdl/Extractors/Bandcamp.cs               3
```