### PR TITLE
GHA: Format .NET in CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.sln'
+      - '.editorconfig'
 
   pull_request:
     branches:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,32 @@
+name: .NET format
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.sln'
+      - '.editorconfig'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: Format code
+      run: dotnet format --verify-no-changes


### PR DESCRIPTION
This makes sure the code is formatted with `dotnet format` in CI.