### PR TITLE
Add `--retry-not-found`

### DIFF
--- a/slsk-batchdl/Config.cs
+++ b/slsk-batchdl/Config.cs
@@ -58,6 +58,7 @@ public class Config
     public bool setAlbumMinTrackCount = true;
     public bool setAlbumMaxTrackCount = false;
     public bool skipNotFound = false;
+    public bool retryNotFound = false;
     public bool desperateSearch = false;
     public bool noRemoveSpecialChars = false;
     public bool artistMaybeWrong = false;
@@ -945,6 +946,10 @@ public class Config
                     case "--snf":
                     case "--skip-not-found":
                         setFlag(ref skipNotFound, ref i);
+                        break;
+                    case "--rnf":
+                    case "--retry-not-found":
+                        setFlag(ref retryNotFound, ref i);
                         break;
                     case "--rfp":
                     case "--rfs":

--- a/slsk-batchdl/DownloaderApplication.cs
+++ b/slsk-batchdl/DownloaderApplication.cs
@@ -371,8 +371,12 @@ public class DownloaderApplication
 
                 if (tle.source.State == TrackState.NotFoundLastTime)
                 {
-                    Logger.Info($"{tle.source.Type} download '{tle.source.ToString(true)}' was not found during a prior run, skipping");
-                    continue;
+                    if (config.retryNotFound) {
+                        tle.source.State = TrackState.Initial;
+                    } else {
+                        Logger.Info($"{tle.source.Type} download '{tle.source.ToString(true)}' was not found during a prior run, skipping");
+                        continue;
+                    }
                 }
             }
 


### PR DESCRIPTION
This adds a new flag, `--retry-not-found`, which instructs `sldl` to retry searches for not found items, rather than skipping them.