### PR TITLE
fix: yt-dlp error when downloaded file is not opus format

### DIFF
--- a/slsk-batchdl/Extractors/YouTube.cs
+++ b/slsk-batchdl/Extractors/YouTube.cs
@@ -679,7 +679,8 @@ namespace Extractors
                 return savePathNoExt + ".opus";
 
             string parentDirectory = Path.GetDirectoryName(savePathNoExt);
-            var musicFiles = Directory.GetFiles(parentDirectory, savePathNoExt + ".*", SearchOption.TopDirectoryOnly)
+            string fileName = Path.GetFileName(savePathNoExt);
+            var musicFiles = Directory.GetFiles(parentDirectory, fileName + ".*", SearchOption.TopDirectoryOnly)
                 .Where(file => Utils.IsMusicFile(file) || Utils.IsVideoFile(file))
                 .OrderByDescending(file => Utils.IsMusicFile(file))
                 .ThenBy(file => Utils.IsVideoFile(file));


### PR DESCRIPTION
This fixes issue #68 

When the downloaded file didn't have an opus format, Directory.GetFiles() was receiving a full path instead of just the filename, causing ArgumentException: "Second path fragment must not be a drive or UNC name."

Can be reproduced by using `--yt-dlp-argument "\"{id}\" -f bestaudio[ext!=opus]/best -ci -o \"{savepath-noext}.%(ext)s\" -x --audio-format mp3"`

Updated to pass only the filename (without extension), which resolves the issue.

Thanks for maintaining this project!