### PR TITLE
Fix Spotify playlist extraction 403 (Forbidden)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,16 +325,25 @@ search for 'youtube data', then follow the prompts.
 
 ### Spotify
 Any playlist or album url, or `spotify-likes` for your liked songs, or `spotify-albums` for liked albums.  
-Credentials are required when downloading a private playlist or liked music.
+Spotify API access now requires your own Spotify developer application for all Spotify inputs,
+including public playlists. Spotify also requires the owner of that application to have an
+active Spotify Premium subscription. If you do not have Premium, export the Spotify playlist
+with a Spotify-to-CSV converter and pass the CSV file to Sockseek instead.
 
 #### Using Credentials
 
 <details>
   <summary>Click to expand</summary>
 
-Create a Spotify application at https://developer.spotify.com/dashboard/applications with a redirect url http://127.0.0.1:48721/callback. Obtain an application ID and secret from the created application dashboard.
+Create a Spotify application at https://developer.spotify.com/dashboard/applications with a redirect url http://127.0.0.1:48721/callback. The Spotify account that owns the application must have an active Premium subscription. Obtain an application ID and secret from the created application dashboard.
 
-Start Sockseek with the obtained credentials and an authorized action to trigger the Spotify app login flow:
+For public playlists and albums, pass the application credentials:
+
+```
+sockseek "https://open.spotify.com/playlist/id" --spotify-id 123456 --spotify-secret 123456
+```
+
+For private playlists, liked songs, liked albums, or `--remove-from-source`, start Sockseek with the obtained credentials and an authorized action to trigger the Spotify app login flow:
 
 ```
 sockseek spotify-likes --spotify-id 123456 --spotify-secret 123456 -n 1 --print-tracks
@@ -702,13 +711,13 @@ sockseek "tracks.csv"
 
 ##### Download a Spotify playlist or your liked songs
 ```bash
-sockseek "https://open.spotify.com/playlist/id"
-sockseek "spotify-likes"
+sockseek "https://open.spotify.com/playlist/id" --spotify-id 123456 --spotify-secret 123456
+sockseek "spotify-likes" --spotify-id 123456 --spotify-secret 123456 --spotify-refresh 123456
 ```
 
 ##### Download the albums of a spotify playlist
 ```bash
-sockseek "https://open.spotify.com/playlist/id" -a
+sockseek "https://open.spotify.com/playlist/id" -a --spotify-id 123456 --spotify-secret 123456
 ```
 
 ##### Download a youtube playlist with yt-dlp fallback & retrieving deleted video names
@@ -853,7 +862,7 @@ Example => Run Sockseek every Sunday at 1am, search for missing tracks from the 
 
 ```
 # min   hour    day     month   weekday command
-0 1 * * 0 sockseek https://open.spotify.com/playlist/6sf1WR5grXGJ6dET -c /config -p /data --index-path /data/index.sockseek
+0 1 * * 0 sockseek https://open.spotify.com/playlist/6sf1WR5grXGJ6dET -c /config -p /data --index-path /data/index.sockseek --spotify-id 123456 --spotify-secret 123456
 ```
 
 [crontab.guru](https://crontab.guru/) could be used to help with the scheduling expression.

--- a/Sockseek.Cli/Help.Content.cs
+++ b/Sockseek.Cli/Help.Content.cs
@@ -279,14 +279,22 @@ Input types
 
   Spotify
     Any playlist or album url, or spotify-likes for your liked songs, or spotify-albums for liked
-    albums. Credentials are required when downloading a private playlist or liked music.
+    albums. Spotify API access now requires your own Spotify developer application for all Spotify
+    inputs, including public playlists. Spotify also requires the owner of that application to have
+    an active Spotify Premium subscription. If you do not have Premium, export the Spotify playlist
+    with a Spotify-to-CSV converter and pass the CSV file to Sockseek instead.
 
     Using Credentials
       Create a Spotify application at https://developer.spotify.com/dashboard/applications with a
-      redirect url http://127.0.0.1:48721/callback. Obtain an application ID and secret from the
-      created application dashboard.
-      Start Sockseek with the obtained credentials and an authorized action to trigger the Spotify
-      app login flow:
+      redirect url http://127.0.0.1:48721/callback. The Spotify account that owns the application
+      must have an active Premium subscription. Obtain an application ID and secret from the created
+      application dashboard.
+      For public playlists and albums, pass the application credentials:
+
+      sockseek ""https://open.spotify.com/playlist/id"" --spotify-id 123456 --spotify-secret 123456
+
+      For private playlists, liked songs, liked albums, or --remove-from-source, start Sockseek with
+      the obtained credentials and an authorized action to trigger the Spotify app login flow:
 
       sockseek spotify-likes --spotify-id 123456 --spotify-secret 123456 -n 1 --print-tracks
 

--- a/Sockseek.Core/Extractors/Spotify.cs
+++ b/Sockseek.Core/Extractors/Spotify.cs
@@ -1,6 +1,7 @@
 using SpotifyAPI.Web;
 using SpotifyAPI.Web.Auth;
 using Swan;
+using System.Text.Json;
 
 using Sockseek.Core.Models;
 using Sockseek.Core.Jobs;
@@ -32,10 +33,10 @@ namespace Sockseek.Core.Extractors;
 
             bool needLogin = input == "spotify-likes" || input == "spotify-albums" || extraction.RemoveTracksFromSource;
 
-            if (needLogin && _spotify.Token.Length == 0 && (_spotify.ClientId.Length == 0 || _spotify.ClientSecret.Length == 0))
+            if (needLogin && string.IsNullOrEmpty(_spotify.Token) && (string.IsNullOrEmpty(_spotify.ClientId) || string.IsNullOrEmpty(_spotify.ClientSecret)))
                 throw new Exception("Credentials are required when downloading liked music or removing from source playlists.");
 
-            spotifyClient = new Spotify(_spotify.ClientId, _spotify.ClientSecret, _spotify.Token, _spotify.Refresh);
+            spotifyClient = new Spotify(_spotify.ClientId ?? "", _spotify.ClientSecret ?? "", _spotify.Token ?? "", _spotify.Refresh ?? "");
             await spotifyClient.Authorize(needLogin, extraction.RemoveTracksFromSource);
 
             Job result;
@@ -75,18 +76,25 @@ namespace Sockseek.Core.Extractors;
                     SockseekLog.Info("Loading Spotify playlist");
                     (playlistName, playlistUri, songs) = await spotifyClient.GetPlaylist(input, max, off);
                 }
-                catch (SpotifyAPI.Web.APIException)
+                catch (APIException ex)
                 {
                     if (!needLogin && !spotifyClient.UsedDefaultCredentials)
                     {
                         await spotifyClient.Authorize(true, extraction.RemoveTracksFromSource);
-                        (playlistName, playlistUri, songs) = await spotifyClient.GetPlaylist(input, max, off);
+                        try
+                        {
+                            (playlistName, playlistUri, songs) = await spotifyClient.GetPlaylist(input, max, off);
+                        }
+                        catch (APIException retryEx)
+                        {
+                            throw SpotifyApiRequestException.Create("Spotify playlist request after user authorization", retryEx);
+                        }
                     }
                     else if (!needLogin)
                     {
-                        throw new Exception("Spotify playlist not found (it may be set to private, but no credentials have been provided).");
+                        throw SpotifyApiRequestException.Create("Spotify playlist request", ex);
                     }
-                    else throw;
+                    else throw SpotifyApiRequestException.Create("Spotify playlist request", ex);
                 }
 
                 if (!string.IsNullOrWhiteSpace(playlistUri))
@@ -118,6 +126,68 @@ namespace Sockseek.Core.Extractors;
     }
 
 
+    public sealed class SpotifyApiRequestException : Exception
+    {
+        private readonly APIException apiException;
+
+        private SpotifyApiRequestException(string message, APIException apiException)
+            : base(message)
+        {
+            this.apiException = apiException;
+        }
+
+        public static SpotifyApiRequestException Create(string operation, APIException apiException)
+            => new($"{operation} failed: {Describe(apiException)}", apiException);
+
+        public override string ToString()
+            => $"{base.ToString()}{Environment.NewLine}{Environment.NewLine}Original Spotify API exception:{Environment.NewLine}{apiException}";
+
+        private static string Describe(APIException exception)
+        {
+            if (exception.Response == null)
+                return exception.Message;
+
+            var parts = new List<string>
+            {
+                $"HTTP {(int)exception.Response.StatusCode} {exception.Response.StatusCode}",
+            };
+
+            if (!string.IsNullOrWhiteSpace(exception.Response.ContentType))
+                parts.Add($"content-type={exception.Response.ContentType}");
+
+            var body = FormatBody(exception.Response.Body);
+            if (!string.IsNullOrWhiteSpace(body))
+                parts.Add($"body={body}");
+
+            if (exception.Response.Headers != null
+                && exception.Response.Headers.TryGetValue("Retry-After", out var retryAfter)
+                && !string.IsNullOrWhiteSpace(retryAfter))
+            {
+                parts.Add($"retry-after={retryAfter}");
+            }
+
+            return string.Join("; ", parts);
+        }
+
+        private static string? FormatBody(object? body)
+        {
+            if (body == null)
+                return null;
+            if (body is string text)
+                return text;
+
+            try
+            {
+                return JsonSerializer.Serialize(body);
+            }
+            catch
+            {
+                return body.ToString();
+            }
+        }
+    }
+
+
     public class Spotify
     {
         private EmbedIOAuthServer _server;
@@ -134,10 +204,10 @@ namespace Sockseek.Core.Extractors;
 
         public Spotify(string clientId = "", string clientSecret = "", string token = "", string refreshToken = "")
         {
-            _clientId           = clientId;
-            _clientSecret       = clientSecret;
-            _clientToken        = token;
-            _clientRefreshToken = refreshToken;
+            _clientId           = clientId ?? "";
+            _clientSecret       = clientSecret ?? "";
+            _clientToken        = token ?? "";
+            _clientRefreshToken = refreshToken ?? "";
 
             if (_clientToken.Length == 0 && (_clientId.Length == 0 || _clientSecret.Length == 0))
             {

--- a/Sockseek.Core/Extractors/Spotify.cs
+++ b/Sockseek.Core/Extractors/Spotify.cs
@@ -33,8 +33,8 @@ namespace Sockseek.Core.Extractors;
 
             bool needLogin = input == "spotify-likes" || input == "spotify-albums" || extraction.RemoveTracksFromSource;
 
-            if (needLogin && string.IsNullOrEmpty(_spotify.Token) && (string.IsNullOrEmpty(_spotify.ClientId) || string.IsNullOrEmpty(_spotify.ClientSecret)))
-                throw new Exception("Credentials are required when downloading liked music or removing from source playlists.");
+            if (string.IsNullOrEmpty(_spotify.ClientId) || string.IsNullOrEmpty(_spotify.ClientSecret))
+                throw new Exception("Spotify client ID and secret are required. Create a Spotify developer app and pass --spotify-id and --spotify-secret.");
 
             spotifyClient = new Spotify(_spotify.ClientId ?? "", _spotify.ClientSecret ?? "", _spotify.Token ?? "", _spotify.Refresh ?? "");
             await spotifyClient.Authorize(needLogin, extraction.RemoveTracksFromSource);
@@ -78,7 +78,7 @@ namespace Sockseek.Core.Extractors;
                 }
                 catch (APIException ex)
                 {
-                    if (!needLogin && !spotifyClient.UsedDefaultCredentials)
+                    if (!needLogin)
                     {
                         await spotifyClient.Authorize(true, extraction.RemoveTracksFromSource);
                         try
@@ -89,10 +89,6 @@ namespace Sockseek.Core.Extractors;
                         {
                             throw SpotifyApiRequestException.Create("Spotify playlist request after user authorization", retryEx);
                         }
-                    }
-                    else if (!needLogin)
-                    {
-                        throw SpotifyApiRequestException.Create("Spotify playlist request", ex);
                     }
                     else throw SpotifyApiRequestException.Create("Spotify playlist request", ex);
                 }
@@ -198,23 +194,12 @@ namespace Sockseek.Core.Extractors;
         private SpotifyClient? _client;
         private bool loggedIn = false;
 
-        public const string encodedSpotifyId = "MWJmNDY5M1bLaH9WJiYjFhNGY0MWJjZWQ5YjJjMWNmZGJiZDI=";
-        public const string encodedSpotifySecret = "Y2JlM2QxYTE5MzJkNDQ2MmFiOGUy3shTuf4Y2JhY2M3ZDdjYWU=";
-        public bool UsedDefaultCredentials { get; private set; }
-
         public Spotify(string clientId = "", string clientSecret = "", string token = "", string refreshToken = "")
         {
             _clientId           = clientId ?? "";
             _clientSecret       = clientSecret ?? "";
             _clientToken        = token ?? "";
             _clientRefreshToken = refreshToken ?? "";
-
-            if (_clientToken.Length == 0 && (_clientId.Length == 0 || _clientSecret.Length == 0))
-            {
-                _clientId           = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encodedSpotifyId.Replace("1bLaH9", "")));
-                _clientSecret       = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encodedSpotifySecret.Replace("3shTuf4", "")));
-                UsedDefaultCredentials = true;
-            }
         }
 
         public async Task Authorize(bool login = false, bool needModify = false)

--- a/Sockseek.Core/Extractors/Spotify.cs
+++ b/Sockseek.Core/Extractors/Spotify.cs
@@ -370,25 +370,25 @@ namespace Sockseek.Core.Extractors;
             var p          = await _client.Playlists.Get(playlistId);
 
             var songs = new List<SongJob>();
-            int limit = Math.Min(max, 100);
+            int limit = Math.Min(max, 50);
             int num   = offset + 1;
 
             while (true)
             {
-                var tracks = await _client.Playlists.GetItems(playlistId, new PlaylistGetItemsRequest { Limit = limit, Offset = offset });
+                var tracks = await _client.Playlists.GetPlaylistItems(playlistId, new PlaylistGetItemsRequest { Limit = limit, Offset = offset });
 
                 foreach (var track in tracks.Items)
                 {
                     try
                     {
-                        string[] artists = ((IEnumerable<object>)track.Track.ReadProperty("artists")).Select(a => (string)a.ReadProperty("name")).ToArray();
+                        string[] artists = ((IEnumerable<object>)track.Item.ReadProperty("artists")).Select(a => (string)a.ReadProperty("name")).ToArray();
                         var query = new SongQuery
                         {
                             Artist = artists[0],
-                            Album  = (string)track.Track.ReadProperty("album").ReadProperty("name"),
-                            Title  = (string)track.Track.ReadProperty("name"),
-                            Length = (int)track.Track.ReadProperty("durationMs") / 1000,
-                            URI    = (string)track.Track.ReadProperty("uri"),
+                            Album  = (string)track.Item.ReadProperty("album").ReadProperty("name"),
+                            Title  = (string)track.Item.ReadProperty("name"),
+                            Length = (int)track.Item.ReadProperty("durationMs") / 1000,
+                            URI    = (string)track.Item.ReadProperty("uri"),
                         };
                         songs.Add(new SongJob(query) { ItemNumber = num++ });
                     }
@@ -397,7 +397,7 @@ namespace Sockseek.Core.Extractors;
 
                 if (tracks.Items.Count < limit || songs.Count >= max) break;
                 offset += limit;
-                limit   = Math.Min(max - songs.Count, 100);
+                limit   = Math.Min(max - songs.Count, 50);
             }
 
             return (p.Name, p.Id, songs);


### PR DESCRIPTION
This is the actual fix for #160.

The lib bump to SpotifyAPI.Web 7.4.2 back in March added `Playlists.GetPlaylistItems()` (which hits `/playlists/{id}/items`), but `GetPlaylist()` in `Spotify.cs` was never switched over - it's still calling the old `Playlists.GetItems()`, which is now just a thin obsolete wrapper around the dead `/playlists/{id}/tracks` endpoint. So the package bump didn't actually change any behavior, which is why people are still hitting `403 Forbidden` on 2.7.0 and current master.

This swaps the call to `GetPlaylistItems()` and updates the field access from `track.Track` to `track.Item`, since the `/items` response renames that field. Also dropped the page size from 100 to 50, since that's the documented max for `/items` (the old `/tracks` endpoint allowed 100).

Tested against the live API - confirmed `/tracks` 403s even for playlists you own, while `/items` returns 200 for the same playlist. Built and ran against a few hundred track playlist end to end, extraction and downloads both work now.
